### PR TITLE
feat: Add Manet to Related software section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This section includes software, guides and tools that are not *specifically* des
 - [Threadfin](https://github.com/Threadfin/Threadfin) - M3U proxy for Jellyfin (Based on xTeVe).
 - [TRaSH Guides](https://trash-guides.info/) - Easy-to-understand guides for Sonarr, Radarr, and Bazarr, along with related tools.
 - [watchstate](https://github.com/ArabCoders/watchstate) - Sync play state between different media servers.
+- [Manet ` 🔸 `](https://stormlight.space/@manet) - iOS app for streaming your music from Jellyfin, written in Swift.
 
 
 ## Contribute


### PR DESCRIPTION
feat: Add [Manet (iOS app for streaming your music from Jellyfin, written in Swift)](https://stormlight.space/@manet) to the Related software section of the README.md.

It would be nice to structure this part of the README a bit more. Maybe into platforms? Or a table with different platforms where the software is available?

There area ton of apps specifically made for Jellyfin that should be added to the list. [The "official" list](https://jellyfin.org/downloads/clients/all) is a good start.