### PR TITLE
other: add nodiscc.xsrv.jellyfin ansible role

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@
 - [reiverr ` 🔸 `](https://github.com/aleksilassila/reiverr) - Combined interface for JF, TMDB, Radarr and Sonarr.
 - [subgen](https://github.com/McCloudS/subgen) - Autogenerate subtitles using OpenAI Whisper Model via Jellyfin.
 - [TitleCardMaker](https://github.com/CollinHeist/TitleCardMaker) - Automated title card maker for Plex, Jellyfin, and Emby.
-- [ytdl-sub](https://github.com/jmbannon/ytdl-sub) - Automate downloading and metadata generation with YoutubeDL.
 - [wizarr](https://github.com/Wizarrrr/wizarr) - Advanced user invitation and management system.
+- [ytdl-sub](https://github.com/jmbannon/ytdl-sub) - Automate downloading and metadata generation with YoutubeDL.
+- [xsrv.jellyfin](https://github.com/nodiscc/xsrv/tree/master/roles/jellyfin) - Ansible role to deploy and configure Jellyfin.
+
 
 #### 📜 Snippets
 


### PR DESCRIPTION
Hi,

this PR adds the [xsrv.jellyfin](https://github.com/nodiscc/xsrv/tree/master/roles/jellyfin) ansible role, which can be used to deploy Jellyfin on any Debian-based Linux machine.

The role can be used from the [xsrv](https://xsrv.readthedocs.io/en/latest/) command-line tool/ansible wrapper, or with ansible [command-line](https://docs.ansible.com/ansible/latest/user_guide/command_line_tools.html) tools. Optionally it integrates with [netdata](https://github.com/nodiscc/xsrv/tree/master/roles/monitoring_netdata) for instance health monitoring, [apache](https://github.com/nodiscc/xsrv/tree/master/roles/apache) for reverse proxy and SSL/TLS certificate management, [rsnapshot](https://github.com/nodiscc/xsrv/tree/master/roles/backup) for automatic backups, and [samba](https://github.com/nodiscc/xsrv/tree/master/roles/samba) for easy media upload.

Detailed installation/configuration documentation can be found at https://xsrv.readthedocs.io/en/latest/installation.html, but here is the short version using ansible command-line tools and self-signed certificates:

```bash
# create a project directory
$ mkdir -p ~/playbooks/myproject && cd ~/playbooks/myproject
# install ansible in a python virtualenv
$ python3 -m venv .venv
$ source .venv/bin/activate
$ pip3 install ansible
```

Create required files and directories (replace my.CHANGEME.org with the address of the server where jellyfin will be deployed, and other CHANGEME values with values of your choice)


```yaml
# requirements.yml
collections:
  - name: https://gitlab.com/nodiscc/xsrv.git
    type: git
    version: release # or master to get the latest, development version
```

```yaml
# inventory.yml
all:
  hosts:
    my.CHANGEME.org:
```

```yaml
# playbook.yml
- hosts: my.CHANGEME.org
  roles:
    - nodiscc.xsrv.common # (optional) hardening, firewall, login bruteforce protection
    - nodiscc.xsrv.monitoring # (optional) samba server monitoring
    - nodiscc.xsrv.backup # (optional) automatic local backups
    - nodiscc.xsrv.samba # (optional) manage jellyfin files/library over samba file sharing
    - nodiscc.xsrv.apache # (required in the standard configuration) webserver/reverseproxy and SSL/TLS certificates
    - nodiscc.xsrv.jellyfin
```

```yaml
# $ mkdir host_vars/my.CHANGEME.org
# host_vars/my.CHANGEME.org/my.CHANGEME.org.yml
#ansible_ssh_port: 2234 # SSH port, if different from 22
#ansible_host: 1.2.3.4 # SSH server address, if my.CHANGEME.org cannot be resolved from DNS
jellyfin_fqdn: "media.CHANGEME.org" # domain name of the jellyfin instance
```

```yaml
# $ ansible-vault edit host_vars/my.CHANGEME.org/my.CHANGEME.org.vault.yml
ansible_become_pass: "CHANGEME" # sudo password
```

```bash
# make the role/collection available to the ansible project
$ ansible-galaxy collection install --force -r requirements.yml
# deploy the role
$ ansible-playbook -i inventory.yml playbook.yml
```

See [defaults/main.yml](https://github.com/nodiscc/xsrv/blob/master/roles/jellyfin/defaults/main.yml) for all available configuration variables.

I use the role to manage multiple environments/instances for a few years without problems and will keep maintaining it in the foreseeable future.

Let me know if you need additional information.
