### PR TITLE
fix: Update Locatarr URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
 This section includes software, guides and tools that are not *specifically* designed to work with Jellyfin, but can be useful for tasks related to media management or to enhance Jellyfin's functionality.
 
 - [ErsatzTV ` 🔸 `](https://github.com/jasongdove/ErsatzTV) - Stream custom live channels using your own media.
-- [locatarr](https://github.com/BrenekH/locatarr) - A list of tools used to automate the downloading and organization of media files.
+- [locatarr](https://github.com/Locatarr/Locatarr) - A list of tools used to automate the downloading and organization of media files.
   - [radarr](https://github.com/Radarr/Radarr) - Automates downloading & management of movies [`🟣 TRaSH Guide`](https://trash-guides.info/Radarr/).
   - [sonarr](https://github.com/Sonarr/Sonarr) - Automates downloading & management of TV series [`🟣 TRaSH Guide`](https://trash-guides.info/Sonarr/).
   - [tdarr ` 📛 `](https://github.com/HaveAGitGat/Tdarr) - Distributed transcode automation + Library analytics + Video health checking.


### PR DESCRIPTION
The Locatarr repository got moved into its own organization and this PR updates the URL to reflect that change.