### PR TITLE
Remove the "Mobile App" Tag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,5 +102,4 @@ You can also [create a new issue](https://github.com/awesome-jellyfin/awesome-je
 <!--lint ignore unordered-list-marker-style-->
 * Early Release / BETA software ` 🔸 `
 * Closed-Source Software ` 📛 `
-* Mobile App ` 📱 `
 * Stale / Inactive / May not work anymore ` 📅 `


### PR DESCRIPTION
I don't see the tag used anywhere in the readme file, so I don't think the tag is used anymore.