### PR TITLE
Added Jamfin/Deprecated BlueBerry

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -5,7 +5,7 @@
 
 
 
-The preview / screenshots were taken directly from the linked repositories.  
+The preview / screenshots were taken directly from the linked repositories.
 If an image is no longer available or out of date, please create an [issue](https://github.com/awesome-jellyfin/awesome-jellyfin/issues) or a [PR](https://github.com/awesome-jellyfin/awesome-jellyfin/edit/main/THEMES.md).
 
 ## [JellySkin](https://github.com/prayag17/JellySkin) by prayag17
@@ -93,25 +93,25 @@ The final form, the true evolution of the chromic theme saga [` 🔵 Get this Th
 
 ---
 
-## [BlueBerry](https://codeberg.org/Udon/BlueBerry) by Udon
+## [Jamfin](https://github.com/JamsRepos/Jamfin) by JamsRepos
 
-Custom recolor for default Jellyfin Theme [` 🔵 Get this Theme `](https://codeberg.org/Udon/BlueBerry)
+Bringing a modern, sleek glassmorphism design to Jellyfin, enhancing your media server's aesthetics. [` 🔵 Get this Theme `](https://github.com/JamsRepos/Jamfin)
 
 <table>
   <tr>
     <td>
-      <img src="https://codeberg.org/Udon/BlueBerry/media/branch/main/assets/screenshots/screenshot-login.png" />
+      <img src="https://github.com/JamsRepos/Jamfin/raw/main/assets/screenshots/home.jpg" />
     </td>
     <td>
-      <img src="https://codeberg.org/Udon/BlueBerry/media/branch/main/assets/screenshots/screenshot-home.png" />
+      <img src="https://github.com/JamsRepos/Jamfin/raw/main/assets/screenshots/details.jpg" />
     </td>
   </tr>
   <tr>
     <td>
-      <img src="https://codeberg.org/Udon/BlueBerry/media/branch/main/assets/screenshots/screenshot-detail.png" />
+      <img src="https://github.com/JamsRepos/Jamfin/raw/main/assets/screenshots/library.jpg" />
     </td>
     <td>
-      <img src="https://codeberg.org/Udon/BlueBerry/media/branch/main/assets/screenshots/screenshot-admin.png" />
+      <img src="https://github.com/JamsRepos/Jamfin/raw/main/assets/screenshots/admin.jpg" />
     </td>
   </tr>
 </table>

--- a/THEMES.md
+++ b/THEMES.md
@@ -118,6 +118,31 @@ Bringing a modern, sleek glassmorphism design to Jellyfin, enhancing your media 
 
 ---
 
+## [BlueBerry ` 📅 `](https://codeberg.org/Udon/BlueBerry) by Udon
+
+Custom recolor for default Jellyfin Theme [` 🔵 Get this Theme `](https://codeberg.org/Udon/BlueBerry)
+
+<table>
+  <tr>
+    <td>
+      <img src="https://codeberg.org/Udon/BlueBerry/media/branch/main/assets/screenshots/screenshot-login.png" />
+    </td>
+    <td>
+      <img src="https://codeberg.org/Udon/BlueBerry/media/branch/main/assets/screenshots/screenshot-home.png" />
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <img src="https://codeberg.org/Udon/BlueBerry/media/branch/main/assets/screenshots/screenshot-detail.png" />
+    </td>
+    <td>
+      <img src="https://codeberg.org/Udon/BlueBerry/media/branch/main/assets/screenshots/screenshot-admin.png" />
+    </td>
+  </tr>
+</table>
+
+---
+
 ## [Jellyfin Better Styles](https://github.com/Tetrax-10/jellyfin-better-styles) by Tetrax-10
 
 This theme preserves the original aesthetics while upgrading layout and animations for a more polished look and feel.
@@ -134,6 +159,11 @@ Better Movie/TV page layout, improved card animation on hover. [` 🔵 Get this 
     </td>
   </tr>
 </table>
+
+---
+
+<!--lint ignore unordered-list-marker-style-->
+* Stale / Inactive / May not work anymore ` 📅 `
 
 ---
 


### PR DESCRIPTION
It seems the original author has recently deprecated their project https://codeberg.org/Udon/BlueBerry so i've added the key to the themes and added a deprecated notice next to their theme.

I originally had removed this completely but thought that was a bit harsh but if you want me to remove it and just out-right replace it, let me know.