### PR TITLE
refactor: mark vue as official

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -22,7 +22,7 @@ clients:
   - name: "Jellyfin Vue"
     targets: [ Browser ]
     oss: https://github.com/jellyfin/jellyfin-vue
-    official: false
+    official: true
     beta: true
     downloads:
       - icon: demo

--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -31,6 +31,9 @@ clients:
       - icon: docker-hub
         url: https://github.com/jellyfin/jellyfin-vue/pkgs/container/jellyfin-vue
 
+      - icon: github
+        url: https://github.com/jellyfin/jellyfin-vue/actions/workflows/release.yml
+
   - name: "JellyCon"
     targets: [ Kodi ]
     oss: https://github.com/jellyfin/jellycon


### PR DESCRIPTION
Vue is indeed an official client.

A few more things, but out of the scope of this PR and leaving it up to the maintainers of this curated list:

* Not sure if music/reader distinctions are just for clients that are focused in those specific media types or it's applicable if it's supported. In the case of Vue, although it wants to cover all use cases, I mainly use Jellyfin for listening music, so the music playback it's one of the things that I think it does really good. We have [a cool fullscreen player](https://github.com/jellyfin/jellyfin-vue/pull/520) and a [spectogram](https://github.com/jellyfin/jellyfin-vue/pull/2043).
* We also have builds for Windows/MacOS/Linux using Tauri but it's provided in a best-effort basis and we don't ship it "first and foremost". We have them continuosly built and delivered though [GitHub Actions](https://github.com/jellyfin/jellyfin-vue/actions/workflows/release.yml) (check artifacts for a run and you'll find it). We do the same thing for PRs, all the building pipeline is the same regardless. 