### PR TITLE
VidHub added as client

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -127,6 +127,16 @@ clients:
       - icon: apple-appstore
         url: https://apps.apple.com/app/id1136220934?mt=8
 
+  - name: 'VidHub'
+    targets: [ iOS, AppleTV, macOS ]
+    website: https://okaapps.com/product/1659622164
+    price:
+      free: true
+      paid: true
+    downloads:
+      - icon: apple-appstore
+        url: https://apps.apple.com/us/app/vidhub-video-library-player/id1659622164
+
   - name: "sonixd"
     targets: [ Browser ]
     types: [ Music ]


### PR DESCRIPTION
Hello,

This PR adds VidHub as a desktop, iOS/iPadOS/TvOS client:

https://okaapps.com/product/1659622164

https://apps.apple.com/us/app/vidhub-video-library-player/id1659622164

It's a direct competitor of Infuse, but works better (and somehow way better in local network) if you'd ask me.

Since I could not see in this list, I humbly tried to add to yaml file so it could populated on the next build.