### PR TITLE
Add streamystats

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 - [OpenSubtitlesDownload](https://github.com/emericg/OpenSubtitlesDownload) - Automatically or manually download subtitles using CLI/Gnome/KDE. 
 - [Playlifin](https://gitlab.com/Krafting/playlifin-gtk) - Converts YouTube Music playlists to Jellyfin playlists.
 - [reiverr ` 🔸 `](https://github.com/aleksilassila/reiverr) - Combined interface for JF, TMDB, Radarr and Sonarr.
+- [streamystats](https://github.com/fredrikburmester/streamystats) - Statistics service for Jellyfin, providing analytics and data visualization.
 - [subgen](https://github.com/McCloudS/subgen) - Autogenerate subtitles using OpenAI Whisper Model via Jellyfin.
 - [TitleCardMaker](https://github.com/CollinHeist/TitleCardMaker) - Automated title card maker for Plex, Jellyfin, and Emby.
 - [wizarr](https://github.com/Wizarrrr/wizarr) - Advanced user invitation and management system.


### PR DESCRIPTION
This Pull Request adds streamystats to the list. Streamystats is a statistics service for Jellyfin, providing analytics and data visualization.

Resolves #119 