### PR TITLE
(auto) Add `ElegantFin` to Awesome Jellyfin

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 ## 👾 Other
 
 - [autoscan `📅`](https://github.com/Cloudbox/autoscan) - Replaces the default Plex and Emby behaviour for picking up changes on the file system.
+- [ElegantFin](https://github.com/lscambo13/ElegantFin/blob/main/README.md) - A visually appealing Jellyfin theme that enhances the user interface with modern layouts, animations, and a streamlined design.
 - [Fixarr ` 🔸 `](https://github.com/sachinsenal0x64/FIXARR) - Media Renamer and Backup tool. (Backup still WIP)
 - [jelly-clipper ` 🔸 `](https://github.com/arnolicious/jelly-clipper) - A web application for creating, sharing, and managing video clips from your Jellyfin media library.
 - [Jellyfin-Auto-Collections](https://github.com/ghomasHudson/Jellyfin-Auto-Collections) - A tool to automatically make and update collections based on internet lists such as IMDb and letterboxd.


### PR DESCRIPTION
Adds **[ElegantFin](https://github.com/ElegantFin)** to the README.

Closes #123

(automatically generated)