### PR TITLE
Add Finer into clients

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -469,6 +469,18 @@ clients:
         owner: tsukinaha
         repo: tsukimi
 
+  - name: "Finer"
+    targets: [ macOS, iOS ]
+    types: [ Music ]
+    website: https://monk-studio.com/finer
+    official: false
+    beta: false
+    price:
+      free: true
+    downloads:
+      - type: app-store
+        id: "6738301953"
+
 targets:
   - key: Browser
     display: "🌎 Browser-Based"


### PR DESCRIPTION
A new Jellyfin music client, which supports Mac/iPad/iPhone: https://monk-studio.com/finer

![og5](https://github.com/user-attachments/assets/9633ed17-0cf0-49b1-9d75-2626d07d2962)
