### PR TITLE
Add Trailerfin

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@
 - [SuggestArr](https://github.com/giuseppe99barchetta/SuggestArr) - Automatically request suggested movies and TV shows to [Jellyseerr](https://github.com/Fallenbagel/jellyseerr) based on recently watched.
 - [TitleCardMaker](https://github.com/CollinHeist/TitleCardMaker) - Automated title card maker for Plex, Jellyfin, and Emby.
 - [trailarr](https://github.com/nandyalu/trailarr) - Manages trailer downloads for your Radarr and Sonarr libraries.
+- [trailerfin](https://github.com/Pukabyte/trailerfin) - automatically retrieve and create strm links to IMDB trailers and places them in backdrops folder to view trailers on the details page
 - [tunarr](https://github.com/chrisbenincasa/tunarr) - Create custom live TV channels from your Plex or Jellyfin library with a web UI and IPTV support.
 - [wizarr](https://github.com/Wizarrrr/wizarr) - Advanced user invitation and management system.
 - [xsrv.jellyfin](https://github.com/nodiscc/xsrv/tree/master/roles/jellyfin) - Ansible role to deploy and configure Jellyfin.


### PR DESCRIPTION
Trailerfin is a tool for automatically retrieving and refreshing IMDb trailer links for your media library. Instead of downloading the trailer locally, it will create a .strm file that Jellyfin can use to play the video.
It will check the expiration of the link and only update when the link has expired.