### PR TITLE
Add google play link for Wholphin

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -734,6 +734,8 @@ clients:
     official: false
     beta: false
     downloads:
+      - type: google-play
+        id: com.github.damontecres.wholphin
       - type: github
         owner: damontecres
         repo: Wholphin


### PR DESCRIPTION
Wholphin is now available on the play store, so add the link here