### PR TITLE
Add Moonfin for Android TV, Roku, webOS, and Tizen to CLIENTS.yaml

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -781,18 +781,22 @@ clients:
         type: github
         owner: Moonfin-Client
         repo: AndroidTV-FireTV
+        label: AndroidTV
       - 
         type: github
         owner: Moonfin-Client
         repo: Roku
+        label: Roku
       - 
         type: github
         owner: Moonfin-Client
         repo: webOS
+        label: webOS
       - 
         type: github
         owner: Moonfin-Client
         repo: Tizen
+        label: Tizen
 
   - name: ampcast
     targets: [Browser, Windows, Linux, macOS]


### PR DESCRIPTION
This pull request adds new entries for the Moonfin client to Android TV and Roku.