### PR TITLE
Add Sunkfin client information to clients.yaml

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -19,6 +19,15 @@ clients:
       - type: app-store
         id: "1604098728"
 
+  - name: "Sunkfin"
+    targets: [iOS]
+    oss: https://github.com/jackcrane/sunkfin
+    official: false
+    beta: false
+    downloads:
+      - type: app-store
+        id: "6743207349"
+
   - name: "Jellyfin Vue"
     targets: [Browser]
     oss: https://github.com/jellyfin/jellyfin-vue


### PR DESCRIPTION
This pull request adds a new third-party iOS client, "Sunkfin", to the list of clients in the `clients.yaml` file.

New client addition:

* Added "Sunkfin" as an unofficial, non-beta iOS client with its App Store ID and open-source repository link to `assets/clients/clients.yaml`.

Sunkfin is a simple ios only client that is focused on offline playability