### PR TITLE
Add Breezyfin to clients.yaml

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -901,6 +901,19 @@ clients:
       - type: app-store
         id: "6748783768"
 
+  - name: "Breezyfin"
+    targets: [WebOS]
+    oss: https://github.com/botagas/Breezyfin
+    official: false
+    beta: true
+    price:
+      free: true
+      paid: false
+    downloads:
+      - type: github
+        owner: botagas
+        repo: Breezyfin
+
 targets:
   - key: Browser
     display: "🌎 Browser-Based"


### PR DESCRIPTION
This PR adds a new entry for the Breezyfin client. It is currently in the early stages of development (in my humble opinion) as I've been working at it for the past couple of months only. Thus, I am defining a `beta` tag just in case.
