### PR TITLE
feat(clients): add Dee Jellie music client

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -900,6 +900,19 @@ clients:
     downloads:
       - type: app-store
         id: "6748783768"
+          
+  - name: Dee Jellie
+    targets: [iOS, AppleTV, macOS]
+    types: [Music]
+    website: https://www.deejellie.com
+    official: false
+    beta: false
+    price:
+      free: false
+      paid: true
+    downloads:
+      - type: app-store
+        id: "6755585736"
 
 targets:
   - key: Browser


### PR DESCRIPTION
### Summary

Adds **Dee Jellie**, a third-party Jellyfin music client for iOS, Apple TV, and macOS, to `assets/clients/clients.yaml`.

### Details

- **Name:** Dee Jellie  
- **Targets:** iOS, AppleTV, macOS  
- **Type:** Music  
- **Official:** false  
- **Beta:** false  
- **Pricing:** Paid (App Store)  
- **Website:** https://www.deejellie.com  
- **App Store ID:** 6755585736  

This change updates the source YAML file only (`assets/clients/clients.yaml`). `CLIENTS.md` will be regenerated automatically by the project checks.