### PR TITLE
feat: add multiple new clients

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -964,6 +964,19 @@ clients:
         owner: flex36ty
         repo: elefin
 
+  - name: Jellify
+    targets: [iOS, Android]
+    types: [Music]
+    oss: https://github.com/Jellify-Music/App
+    downloads:
+      - type: github
+        owner: Jellify-Music
+        repo: App
+      - type: shield
+        icon: App Store
+        label: TestFlight
+        url: https://testflight.apple.com/join/etVSc7ZQ
+
 targets:
   - key: Browser
     display: "🌎 Browser-Based"


### PR DESCRIPTION
## Summary

Add 5 new Jellyfin clients and adapt 1 existing client entry.

## New Clients

- **JellyCine** ([repo](https://github.com/sureshfizzy/JellyCine)) — Closes #458
- **Playtorrio** ([repo](https://github.com/ayman708-UX/PlayTorrio)) — Closes #456
- **JellyTV** ([website](https://jellytv.app/en)) — Closes #392
- **Elefin** ([repo](https://github.com/flex36ty/elefin)) — Closes #378
- **Jellify** ([repo](https://github.com/Jellify-Music/App)) — Closes #377

## Updated Clients

- **Reefin** ([repo](https://github.com/SKULSHADY/reefin)) — Added Android TV target, OSS link, and updated website — Closes #390