### PR TITLE
feat: add Jellyfin Book Cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - [InPlayerEpisodePreview](https://github.com/Namo2/InPlayerEpisodePreview) - Adds an episode list to the video player.
 - [intro-skipper](https://github.com/intro-skipper/intro-skipper) - Fingerprint audio to automatically detect intro and outro segments in Jellyfin.
 - [jellyfin-ani-sync](https://github.com/vosmiic/jellyfin-ani-sync) - Automatically tracks and synchronizes anime watching progress between Jellyfin and [Anilist](https://anilist.co/) and other services.
+- [Jellyfin Book Cover](https://github.com/GeiserX/jellyfin-plugin-book-cover) - Fallback cover image provider for books and audiobooks, extracting covers from PDF, EPUB, and audio files with mislabeled codec tag handling.
 - [jellyfin-editors-choice-plugin](https://github.com/lachlandcp/jellyfin-editors-choice-plugin) - Adds a Netflix-style, full-width content slider to the home page to feature selected content.
 - [Jellyfin-Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced) - Adds keyboard shortcuts, subtitle styling, TMDB reviews, Jellyseerr search and request integration, and other improvements to Jellyfin.
 - [jellyfin-icon-metadata](https://github.com/Druidblack/jellyfin-icon-metadata) - Adds metadata provider icons to Jellyfin.


### PR DESCRIPTION
## Summary

- Adds [Jellyfin Book Cover](https://github.com/GeiserX/jellyfin-plugin-book-cover) to the Plugins section.
- Fallback cover image provider for books and audiobooks, extracting covers from PDF, EPUB, and audio files with mislabeled codec tag handling.
- Inserted alphabetically per contribution guidelines.

Generated with [Claude Code](https://claude.com/claude-code)