### PR TITLE
feat: add Jellyfin Encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@
 - [jellyfin-cover-art-generator](https://github.com/Tetrax-10/jellyfin-cover-art-generator) - CLI tool to generate Jellyfin styled library coverart from a backdrop.
 - [Jellyfin-Cover-Maker](https://github.com/KartoffelChipss/Jellyfin-Cover-Maker) - A website to easily create consistent covers and posters for your Jellyfin libraries.
 - [JellyfinEasyMetadataManager](https://github.com/CesarBianchi/JellyfinEasyMetadataManager) - A desktop tool for managing and editing metadata in Jellyfin libraries.
+- [Jellyfin Encoder](https://github.com/GeiserX/jellyfin-encoder) - Automatic 720p HEVC/AV1 transcoding service with NVIDIA and Intel hardware acceleration for mobile-friendly streaming.
 - [Jellyfin-Image-Exporter](https://github.com/Kurotaku-sama/Jellyfin-Image-Exporter) - A script to export images (posters, banners, thumbnails) from your Jellyfin media server's metadata library.
 - [jellyfin-mods](https://github.com/BobHasNoSoul/jellyfin-mods) - A collection of things you can do to personalize Jellyfin.
 - [Jellyfin Notification System](https://github.com/Fahmula/jellyfin-telegram-notifier) - Sends Telegram notifications with media images whenever a new movie, series, season, or episode is added to Jellyfin. `🔸 Stale`


### PR DESCRIPTION
## Summary

- Adds [Jellyfin Encoder](https://github.com/GeiserX/jellyfin-encoder) to the Other section.
- Automatic 720p HEVC/AV1 transcoding service with NVIDIA and Intel hardware acceleration for mobile-friendly streaming.
- Inserted alphabetically per contribution guidelines.

Generated with [Claude Code](https://claude.com/claude-code)