### PR TITLE
feat(plugins): add jelly-subtitles

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@
 - [jellyscrub](https://github.com/nicknsy/jellyscrub) - Smooth mouse-over video scrubbing previews. `🔸 Stale`
   <!--lint ignore list-item-indent awesome-list-item-->
     -  **NOTE:** Jellyfin 10.9 now natively supports trickplay.
-- [jelly-subtitles](https://github.com/GeiserX/jelly-subtitles) - Automatically generates subtitles using local AI models powered by Whisper, with all processing on your server.
 - [JellySTRMprobe](https://github.com/firestaerter3/JellySTRMprobe) - Probes STRM files to extract media information (codec, resolution, duration, audio) that Jellyfin skips during library scans.
+- [jelly-subtitles](https://github.com/GeiserX/jelly-subtitles) - Automatically generates subtitles using local AI models powered by Whisper, with all processing on your server.
 - [media-upload-plugin](https://github.com/grandguyjs/media-upload-plugin) - Media-manager that provides uploads, bulk downloads from URLs, and directory browsing within Jellyfin.
 - [MyAnimeSync](https://github.com/iankiller77/MyAnimeSync) - Automatically synchronizes anime watching progress between Jellyfin and MyAnimeList.
 - [playlist-generator](https://github.com/Eeeeelias/playlist-generator) - Create personal playlists based on your listening history.


### PR DESCRIPTION
## Summary
- Adds [jelly-subtitles](https://github.com/GeiserX/jelly-subtitles) to the Plugins section.
- Jellyfin plugin for local AI-powered subtitle generation using Whisper - all processing stays on your server.
- Entry placed in alphabetical order.
