### PR TITLE
Add MediarrGuard to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
     -  **NOTE:** Jellyfin 10.9 now natively supports trickplay.
 - [JellySTRMprobe](https://github.com/firestaerter3/JellySTRMprobe) - Probes STRM files to extract media information (codec, resolution, duration, audio) that Jellyfin skips during library scans.
 - [media-upload-plugin](https://github.com/grandguyjs/media-upload-plugin) - Media-manager that provides uploads, bulk downloads from URLs, and directory browsing within Jellyfin.
+- [MediarrGuard](https://github.com/acorkran/jellyfin-plugin-mediarrguard) - Detects corrupt media files and automatically requests replacements from Sonarr/Radarr.
 - [MyAnimeSync](https://github.com/iankiller77/MyAnimeSync) - Automatically synchronizes anime watching progress between Jellyfin and MyAnimeList.
 - [playlist-generator](https://github.com/Eeeeelias/playlist-generator) - Create personal playlists based on your listening history.
 - [Plexyfin](https://github.com/cleverdevil/plexyfin) - Automatically synchronize artwork and collections from your Plex Media Server to Jellyfin. Useful for users of Kometa.


### PR DESCRIPTION
## Summary
- Adds [MediarrGuard](https://github.com/acorkran/jellyfin-plugin-mediarrguard) to the Plugins section of the awesome list
- MediarrGuard is a Jellyfin plugin that detects corrupt media files and automatically requests replacements from Sonarr/Radarr
- Entry placed in alphabetical order between `media-upload-plugin` and `MyAnimeSync`

## Test plan
- [ ] Verify the entry follows the existing list format
- [ ] Verify alphabetical ordering is correct
- [ ] Verify the link is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)