### PR TITLE
feat(clients): add ChordCut music client

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -980,6 +980,16 @@ clients:
         label: TestFlight
         url: https://testflight.apple.com/join/etVSc7ZQ
 
+  - name: "ChordCut"
+    targets: [Windows]
+    types: [Music]
+    oss: https://github.com/Futyn-Maker/ChordCut
+    official: false
+    downloads:
+      - type: github
+        owner: Futyn-Maker
+        repo: ChordCut
+
 targets:
   - key: Browser
     display: "🌎 Browser-Based"


### PR DESCRIPTION
## Summary

This PR adds **ChordCut** to the list of clients. ChordCut is a portable accessible Jellyfin music client for Windows written in Python, designed primarily for blind and visually impaired users. It is first and foremost designed to be fully accessible to screen readers such as NVDA and JAWS, and to be fully operable via keyboard without using a mouse.

## Details

- **Name:** ChordCut
- **Targets:** Windows
- **Type:** Music
- **Official:** no
- **OSS:** https://github.com/Futyn-Maker/ChordCut
- **Downloads:** GitHub Releases

> Note: I understand that at the moment this client does not meet the age criterion (minimum 4 weeks), but I decided to submit a PR so that the community has the opportunity to look at it — if it is necessary to wait until enough time has passed, I am ready for that — I hope this won't be a problem :)