### PR TITLE
feat(plugins): add TvGuide

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 - [Static Assets](https://github.com/cleverdevil/jelly-static-assets) - Upload and serve static assets such as CSS, JavaScript, and images directly from Jellyfin.
 - [TeleJelly](https://github.com/hexxone/TeleJelly) - Allows users to sign in through the [Telegram Login Widget](https://core.telegram.org/widgets/login).
 - [TheDwarfsHammer](https://github.com/Kamoba/jellyfin-plugin-thedwarfshammer) - Enhanced collection management and content discovery for Jellyfin.
+- [TvGuide](https://github.com/mattboardman/TvGuide) - Turn your library into a Live TV backend with custom channel management.
 
 
 #### 🏷️ Metadata Providers


### PR DESCRIPTION
# Summary 
------
* Adds [TvGuide](https://github.com/mattboardman/TvGuide) to the plugins section.
* Jellyfin plugin for turning your local libraries into Live TV channels.
* Entry placed in alphabetical order.