### PR TITLE
docs(readme): add AniLiberty STRM Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 ## 🧩 Plugins
 
 <!-- sort list:plugins -->
+- [AniLiberty STRM Plugin](https://github.com/queukat/AniLibriaStrmPlugin) - Generates AniLiberty STRM libraries for Jellyfin with metadata, intro markers, and watch-progress sync.
 - [Gelato](https://github.com/lostb1t/Gelato) - Replaces Jellyfin's default search with Stremio-powered results and can automatically import entire catalogs into your library through scheduled tasks.
 - [HoverTrailer](https://github.com/Fovty/HoverTrailer) - Displays movie trailers on hover.
 - [InPlayerEpisodePreview](https://github.com/Namo2/InPlayerEpisodePreview) - Adds an episode list to the video player.


### PR DESCRIPTION
## Summary
- add AniLiberty STRM Plugin to the plugin list in README.md
- keep the entry short and alphabetically sorted

## Notes
- description is intentionally concise and non-promotional to match the repo guidelines
