### PR TITLE
feat: add WebOS to Litefin targets

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -981,7 +981,7 @@ clients:
         url: https://testflight.apple.com/join/etVSc7ZQ
 
   - name: Litefin
-    targets: [Tizen]
+    targets: [Tizen, WebOS]
     oss: https://github.com/MoazSalem/litefin
     official: false    
     price:


### PR DESCRIPTION
Hi, I noticed @schembriaiden added Litefin to the clients. Thank you for that, but Litefin also supports WebOS ✌️