### PR TITLE
fix: Moonfin webOS and Tizen clients links

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -839,12 +839,12 @@ clients:
       - 
         type: github
         owner: Moonfin-Client
-        repo: webOS
+        repo: Smart-TV
         label: webOS
       - 
         type: github
         owner: Moonfin-Client
-        repo: Tizen
+        repo: Smart-TV
         label: Tizen
       - 
         type: google-play


### PR DESCRIPTION
Hi, moonfin merged webOS and Tizen repos, and the link should now point to Smart-TV instead.