### PR TITLE
feat(plugins): Add Telefin to notification plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 - [jellyfin-plugin-DiscordNotifier](https://github.com/cedev-1/jellyfin-plugin-DiscordNotifier) - Sends notifications of Jellyfin server events to Discord.
 - [jellyfin-plugin-TelegramNotifier](https://github.com/RomainPierre7/jellyfin-plugin-TelegramNotifier) - Receive notifications of Jellyfin server events via Telegram.
 - [NotifySync](https://github.com/peterdu1109/NotifySync) - Adds a notification bell to Jellyfin that displays recent additions.
+- [Telefin](https://github.com/LoloZarro/Telefin) - Jellyfin plugin that enables Telegram notifications for Jellyfin events with many additional features.
 
 
 ### 🔐 Authentication


### PR DESCRIPTION
# Summary
Adds [Telefin](https://github.com/LoloZarro/Telefin) to the "Plugins" under the "Notifications" section in alphabetical order.

# Description
Telefin is a Jellyfin plugin that enables Telegram notifications for Jellyfin events. It allows Jellyfin administrators to configure Telegram bots on a per-user basis, giving each user full control over which events they want to be notified about and how those notifications look.

Every supported Jellyfin event can be individually enabled or disabled. Each event message is fully customizable using placeholders. This enables both simple alerts and highly detailed, personalized notifications.

Telefin is designed to be lightweight, flexible, and easy to configure directly from the Jellyfin admin interface.