### PR TITLE
docs: add jellyfin-plugin-dedupe-continue-watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 <!-- sort list:plugins-playback -->
 - [intro-skipper](https://github.com/intro-skipper/intro-skipper) - Fingerprint audio to automatically detect intro and outro segments in Jellyfin.
 - [jellyfin-plugin-cinemamode](https://github.com/CherryFloors/jellyfin-plugin-cinemamode) - Enables Jellyfin's Cinema Mode with local trailers and pre-rolls.
+- [jellyfin-plugin-dedupe-continue-watching](https://github.com/SloMR/jellyfin-plugin-dedupe-continue-watching) - Deduplicates the Continue Watching row so each series appears only once, using the most recently played episode.
 - [jellyfin-plugin-discontinue-watching](https://github.com/jon4hz/jellyfin-plugin-discontinue-watching) - Lets you remove items from the Continue Watching list without resetting watch progress, with optional auto-hide after inactivity.
 - [jellyfin-plugin-jellysleep](https://github.com/jon4hz/jellyfin-plugin-jellysleep) - Adds sleep timer functionality to Jellyfin.
 - [Jellyfin.Plugin.StreamLimit](https://github.com/JellyboxAD/Jellyfin.Plugin.StreamLimit) - Allows limiting the number of simultaneous streams per user.


### PR DESCRIPTION
## Summary

Adds `jellyfin-plugin-dedupe-continue-watching` to the Playback plugins list.

The plugin deduplicates Jellyfin's Continue Watching row so each series appears only once, represented by the most recently played episode.

## Category

Plugins → Playback

## Checklist

- [x] Added to the correct category
- [x] Kept the description short and descriptive
- [x] Kept the list alphabetically sorted