### PR TITLE
Add Jellyfin Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
 <!-- sort list:plugins-auth -->
 - [jellyfin-plugin-ldapauth](https://github.com/jellyfin/jellyfin-plugin-ldapauth) - Allows the use of LDAP as an auth provider.
 - [jellyfin-plugin-sso](https://github.com/9p4/jellyfin-plugin-sso) - Allows users to sign in through an SSO provider. `🔹 Beta`
+- [Jellyfin Security](https://github.com/ZL154/JellyfinSecurity) - Natively adds TOTP and email 2FA, passkeys, OIDC/SSO sign-in, brute-force protection, IP allowlists, device pairing, trusted browsers, and audit logging to Jellyfin.
 - [TeleJelly](https://github.com/hexxone/TeleJelly) - Allows users to sign in through the [Telegram Login Widget](https://core.telegram.org/widgets/login).
 
 


### PR DESCRIPTION
- Adds Jellyfin Security to the Authentication plugins section.

Jellyfin security is a security suite which adds a whole host of features such as 2fa, passkeys, oidc/sso, and more.
