### PR TITLE
feat(plugins): add macOS random Jellyfin screensaver

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@
 - [Jellyfin Notification System](https://github.com/Fahmula/jellyfin-telegram-notifier) - Sends Telegram notifications with media images whenever a new movie, series, season, or episode is added to Jellyfin. `🔸 Stale`
 - [Jellyfin Segment Editor](https://github.com/intro-skipper/segment-editor) - Manage Jellyfin Media Segment positions.
 - [KefinTweaks](https://github.com/ranaldsgift/KefinTweaks) - Collection of UI enhancements and customization tweaks for Jellyfin.
+- [macos-random-jellyfin-screensaver](https://github.com/ndom91/macos-random-jellyfin-screensaver) - MacOS Screensaver that plays a random Jellyfin item.
 - [MPC-JF](https://github.com/Damocles-fr/MPC-JF) - Launch external media players (MPC-HC, MPC-BE, PotPlayer) from Jellyfin Web or Jellyfin Media Player.
 - [Scyphomote](https://github.com/eiffelbeef/scyphomote) - A dedicated remote control for Jellyfin with support for playback transparency, trickplay previews, and more.
 - [tunarr](https://github.com/chrisbenincasa/tunarr) - Create custom live TV channels from your Plex or Jellyfin library with a web UI and IPTV support.


### PR DESCRIPTION
- Add [macos-random-jellyfin-screensaver](https://github.com/ndom91/macos-random-jellyfin-screensaver)
- It's a macOS `.saver` file that will play a random Jellyfin item on your screen saver.
- Defaults to muted and with subtitles (configurable)

<img width="502" height="548" alt="image" src="https://github.com/user-attachments/assets/0f5f82ac-443e-4750-8f88-1889625fcbd8" />
