### PR TITLE
chore: removed OSS link for Reefin

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -724,7 +724,6 @@ clients:
   - name: "Reefin"
     targets: [Android, AndroidTV]
     website: https://reefin.dev/
-    oss: https://github.com/SKULSHADY/reefin
     downloads:
       - type: google-play
         id: com.shady.reefin


### PR DESCRIPTION
... as the linked repository seems to be empty.

closes #554 