### PR TITLE
feat(clients): add Arnage

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -997,6 +997,21 @@ clients:
         owner: jellyfin
         repo: jellyfin-web
 
+  - name: "Arnage"
+    targets: [Android, AndroidTV, iOS]
+    website: https://community.tfdn.app
+    beta: true
+    price:
+      free: true
+      paid: true
+    downloads:
+      - type: google-play
+        id: app.arnage.arnage
+      - type: shield
+        icon: App Store
+        label: TestFlight
+        url: "https://testflight.apple.com/join/GhurC6uX"
+
 targets:
   - key: Browser
     display: "🌎 Browser-Based"


### PR DESCRIPTION
Adds [Arnage](https://community.tfdn.app) — a third-party Jellyfin client for Android, Android TV and iOS, currently in public beta.

- Freemium: free, with optional paid features
- Android / Android TV via Google Play, iOS via public TestFlight