### PR TITLE
feat: add Achievement Badges, StarTrack, and NetFin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 - [jellyscrub](https://github.com/nicknsy/jellyscrub) - Smooth mouse-over video scrubbing previews. `🔸 Stale`
   <!--lint ignore list-item-indent awesome-list-item-->
     -  **NOTE:** Jellyfin 10.9 now natively supports trickplay.
-- [StarTrack](https://github.com/ZL154/jellyfin-plugin-startrack) - Per-user star ratings for movies and TV shows with poster overlays, media details integration, and a post-playback rating prompt with the ability to integrate letterboxd and its features.
+- [StarTrack](https://github.com/ZL154/jellyfin-plugin-startrack) - Per-user star ratings for movies and TV shows with poster overlays, media details integration, and a post-playback rating prompt with the ability to integrate letterboxd, trakt and simkl and its features.
 - [Static Assets](https://github.com/cleverdevil/jelly-static-assets) - Upload and serve static assets such as CSS, JavaScript, and images directly from Jellyfin. `🔸 Stale`
 
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 - [jellyscrub](https://github.com/nicknsy/jellyscrub) - Smooth mouse-over video scrubbing previews. `🔸 Stale`
   <!--lint ignore list-item-indent awesome-list-item-->
     -  **NOTE:** Jellyfin 10.9 now natively supports trickplay.
+- [StarTrack](https://github.com/ZL154/jellyfin-plugin-startrack) - Per-user star ratings for movies and TV shows with poster overlays, media details integration, and a post-playback rating prompt.
 - [Static Assets](https://github.com/cleverdevil/jelly-static-assets) - Upload and serve static assets such as CSS, JavaScript, and images directly from Jellyfin. `🔸 Stale`
 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 ### 🎨 UI & Customization
 
 <!-- sort list:plugins-ui -->
-- [Achievement Badges](https://github.com/ZL154/AchievementBadges_for_Jellyfin) - Unlockable viewing achievement badges that gamify Jellyfin with milestones like first watch, binge sessions, and late-night viewing.
+- [Achievement Badges](https://github.com/ZL154/AchievementBadges_for_Jellyfin) - Unlockable viewing achievement badges that gamify Jellyfin with milestones like first watch, binge sessions, and late-night viewing with social features such as group chats and messaging.
 - [HoverTrailer](https://github.com/Fovty/HoverTrailer) - Displays movie trailers on hover.
 - [InPlayerEpisodePreview](https://github.com/Namo2/InPlayerEpisodePreview) - Adds an episode list to the video player.
 - [jellyfin-editors-choice-plugin](https://github.com/lachlandcp/jellyfin-editors-choice-plugin) - Adds a Netflix-style, full-width content slider to the home page to feature selected content.
@@ -56,7 +56,7 @@
 - [jellyscrub](https://github.com/nicknsy/jellyscrub) - Smooth mouse-over video scrubbing previews. `🔸 Stale`
   <!--lint ignore list-item-indent awesome-list-item-->
     -  **NOTE:** Jellyfin 10.9 now natively supports trickplay.
-- [StarTrack](https://github.com/ZL154/jellyfin-plugin-startrack) - Per-user star ratings for movies and TV shows with poster overlays, media details integration, and a post-playback rating prompt.
+- [StarTrack](https://github.com/ZL154/jellyfin-plugin-startrack) - Per-user star ratings for movies and TV shows with poster overlays, media details integration, and a post-playback rating prompt with the ability to integrate letterboxd and its features.
 - [Static Assets](https://github.com/cleverdevil/jelly-static-assets) - Upload and serve static assets such as CSS, JavaScript, and images directly from Jellyfin. `🔸 Stale`
 
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 ### 🎨 UI & Customization
 
 <!-- sort list:plugins-ui -->
+- [Achievement Badges](https://github.com/ZL154/AchievementBadges_for_Jellyfin) - Unlockable viewing achievement badges that gamify Jellyfin with milestones like first watch, binge sessions, and late-night viewing.
 - [HoverTrailer](https://github.com/Fovty/HoverTrailer) - Displays movie trailers on hover.
 - [InPlayerEpisodePreview](https://github.com/Namo2/InPlayerEpisodePreview) - Adds an episode list to the video player.
 - [jellyfin-editors-choice-plugin](https://github.com/lachlandcp/jellyfin-editors-choice-plugin) - Adds a Netflix-style, full-width content slider to the home page to feature selected content.

--- a/THEMES.md
+++ b/THEMES.md
@@ -296,6 +296,31 @@ Better Movie/TV page layout, improved card animation on hover. [` 🔵 Get this 
 
 ---
 
+## [NetFin](https://github.com/ya0903/NetFin) by ya0903
+
+A cinematic Netflix-inspired theme with deep dark visuals, refined hover effects, and a focus on poster artwork. [` 🔵 Get this Theme `](https://github.com/ya0903/NetFin)
+
+<table>
+  <tr>
+    <td>
+      <img src="https://github.com/user-attachments/assets/5eee060a-0c1d-4ab3-8b64-027251973997" />
+    </td>
+    <td>
+      <img src="https://github.com/user-attachments/assets/adc6ae25-6687-43b9-aa19-3319794c297b" />
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <img src="https://github.com/user-attachments/assets/192bd752-be1a-462d-a9f2-088f61940f4a" />
+    </td>
+    <td>
+      <img src="https://github.com/user-attachments/assets/69d1e032-e99e-4fdf-af4e-428d7e81252b" />
+    </td>
+  </tr>
+</table>
+
+---
+
 ## [NeutralFin](https://github.com/KartoffelChipss/NeutralFin) by KartoffelChipss
 
 NeutralFin is a custom Jellyfin theme based on [lscambo13's ElegantFin](https://github.com/lscambo13/ElegantFin), featuring a sleek black and grey color scheme for a more neutral and modern look. [` 🔵 Get this Theme `](https://github.com/KartoffelChipss/NeutralFin)


### PR DESCRIPTION
Adds three community projects.

**Plugins → UI & Customization (`README.md`)**

- [Achievement Badges](https://github.com/ZL154/AchievementBadges_for_Jellyfin) - Unlockable viewing achievement badges that gamify Jellyfin with milestones like first watch, binge sessions, and late-night viewing with social features such as group chats and messaging.
- [StarTrack](https://github.com/ZL154/jellyfin-plugin-startrack) - Per-user star ratings for movies and TV shows with poster overlays, media details integration, and a post-playback rating prompt with the ability to integrate letterboxd, trakt and simkl and its features.

**Themes (`THEMES.md`)**

- [NetFin](https://github.com/ya0903/NetFin) by ya0903 - A Netflix-inspired theme with deep dark visuals, refined hover effects, and a focus on poster artwork.
