### PR TITLE
feat(plugins): add Jellyfin-Discord-Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@
 ### 🔐 Authentication
 
 <!-- sort list:plugins-auth -->
+- [Jellyfin-Discord-Auth](https://github.com/EvanTrow/Jellyfin-Discord-Auth) - Allows users to sign in through Discord.
 - [jellyfin-plugin-ldapauth](https://github.com/jellyfin/jellyfin-plugin-ldapauth) - Allows the use of LDAP as an auth provider.
 - [jellyfin-plugin-sso](https://github.com/9p4/jellyfin-plugin-sso) - Allows users to sign in through an SSO provider. `🔹 Beta`
 - [Jellyfin Security](https://github.com/ZL154/JellyfinSecurity) - Natively adds TOTP and email 2FA, passkeys, OIDC/SSO sign-in, brute-force protection, IP allowlists, device pairing, trusted browsers, and audit logging to Jellyfin.


### PR DESCRIPTION
Added [Jellyfin-Discord-Auth](https://github.com/EvanTrow/Jellyfin-Discord-Auth) plugin to the Authentication section.