### PR TITLE
feat: add StarTrack

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 - [jellyscrub](https://github.com/nicknsy/jellyscrub) - Smooth mouse-over video scrubbing previews. `🔸 Stale`
   <!--lint ignore list-item-indent awesome-list-item-->
     -  **NOTE:** Jellyfin 10.9 now natively supports trickplay.
+- [StarTrack](https://github.com/ZL154/jellyfin-plugin-startrack) - Per-user star ratings for movies and TV shows with poster overlays, media details integration, and a post-playback rating prompt with the ability to integrate letterboxd, trakt and simkl and its features.
 - [Static Assets](https://github.com/cleverdevil/jelly-static-assets) - Upload and serve static assets such as CSS, JavaScript, and images directly from Jellyfin. `🔸 Stale`
 
 


### PR DESCRIPTION
Adds a community plugin.

**Plugins → UI & Customization (`README.md`)**

- [StarTrack](https://github.com/ZL154/jellyfin-plugin-startrack) - Per-user star ratings for movies and TV shows with poster overlays, media details integration, and a post-playback rating prompt with the ability to integrate letterboxd, trakt and simkl and its features.
