### PR TITLE
feat(clients): add mellow

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -962,6 +962,18 @@ clients:
         owner: kontell
         repo: pvr.kofin
 
+  - name: "Mellow"
+    targets: [Android]
+    oss: https://github.com/Malinskiy/mellow
+    official: false
+    price:
+      free: true
+      paid: false
+    downloads:
+      - type: github
+        owner: Malinskiy
+        repo: mellow
+
 targets:
   - key: Browser
     display: "🌎 Browser-Based"


### PR DESCRIPTION
Adds [mellow](https://github.com/Malinskiy/mellow) — a third-party Jellyfin client for Android. Offline-first with Android Auto support