### PR TITLE
feat(clients): add Linthra music client

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -949,6 +949,20 @@ clients:
       - type: github
         owner: kontell
         repo: pvr.kofin
+  
+  - name: "Linthra"
+    targets: [Android]
+    types: [Music]
+    oss: https://github.com/TheZupZup/Linthra
+    official: false
+    beta: false
+    downloads:
+      - type: github
+        owner: TheZupZup
+        repo: Linthra
+      - type: shield
+        icon: F-Droid
+        url: https://f-droid.org/packages/io.github.thezupzup.linthra/
 
 targets:
   - key: Browser


### PR DESCRIPTION
## Summary

Adds Linthra to the Jellyfin client directory.

Linthra is an open-source Android music client with support for Jellyfin streaming, offline caching, playlists, favorites, Chromecast, and Android Auto. It also supports Navidrome/Subsonic, Plex, and local music libraries.

## Details

- **Target:** Android
- **Type:** Music
- **Official:** No
- **Status:** Stable
- **Source:** https://github.com/TheZupZup/Linthra
- **Downloads:** GitHub Releases and F-Droid

Screenshots and documentation are available in the project README.