### PR TITLE
Add MuseVu client

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -950,6 +950,17 @@ clients:
         owner: kontell
         repo: pvr.kofin
 
+  - name: "MuseVu"
+    targets: [Android, AndroidTV]
+    official: false
+    website: https://musevu.com
+    price:
+      free: true
+      paid: true
+    downloads:
+      - type: google-play
+        id: com.thefuturecoderx.musevu
+
 targets:
   - key: Browser
     display: "🌎 Browser-Based"


### PR DESCRIPTION
Adds **MuseVu**, a cinematic third-party Jellyfin client for Android phones, tablets and Android TV (freemium: free tier plus an optional paid Pro tier). Fire TV, LG webOS and Samsung Tizen versions are currently in testing and will follow.

- Website: https://musevu.com
- Google Play: https://play.google.com/store/apps/details?id=com.thefuturecoderx.musevu
- Also submitted to the official jellyfin.org clients page: jellyfin/jellyfin.org#1963

Entry appended to `assets/clients/clients.yaml` following the existing schema (targets `[Android, AndroidTV]`, `price: free + paid`, google-play download). Note for transparency: MuseVu launched on Google Play this month (July 2026) and is actively maintained with frequent releases — happy to wait or adjust if you prefer listing after the 4-week mark.