### PR TITLE
Add Seenr to Statistics & Watch History

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@
 - [JellyPlex-Watched](https://github.com/luigi311/JellyPlex-Watched) - Syncs watch history between Jellyfin, Plex, and Emby Servers.
 - [Jellystat](https://github.com/CyferShepard/Jellystat) - Statistics and analytics dashboard for Jellyfin.
 - [jelly-watch-wise](https://github.com/Joker-KP/jelly-watch-wise) - Monitors and enforces Jellyfin watch time limits per user, with API integration and a simple GUI. `🔸 Stale`
+- [Seenr](https://seenr.app/en/integrations/jellyfin) - Tracks the shows, films and anime you watch; syncs from Jellyfin through the Webhook plugin, with imports from Trakt, Simkl and Letterboxd.
 - [streamystats](https://github.com/fredrikburmester/streamystats) - Statistics service for Jellyfin, providing analytics and data visualization.
 - [watchstate](https://github.com/arabcoders/watchstate) - Syncs play state between different media servers.
 


### PR DESCRIPTION
### What this adds

Seenr, a free tracker for TV shows, films and anime, under Companion Apps & Tools > Statistics & Watch History.

### How it works with Jellyfin

It plugs into the official Webhook plugin: you paste a personal URL into Jellyfin and your plays are recorded automatically, on the right season. Nothing to install on the server beyond the Webhook plugin itself, no fork, no custom build.

Setup is documented here, including what is sent and what is not:
https://seenr.app/en/integrations/jellyfin

### Why this section

It sits next to JellyPlex-Watched and watchstate: same subject, different angle. Those sync state between servers. Seenr keeps one history across servers and devices, and can import an existing history from Trakt, Simkl or Letterboxd.

### Notes for maintainers

- Seenr is a hosted service, not self-hosted. Flagging it upfront in case that is a blocker for this list. Happy to move the entry to Related, or to close the PR.
- Free, no ads, no account needed to read the docs.
- Public changelog: https://seenr.app/en/changelog
- Exports use an open documented format, so there is no lock-in: https://seenr.app/en/wlog