### PR TITLE
feat: add plex2jellyfin to Media Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@
 - [jellysweep](https://github.com/jon4hz/jellysweep) - Automatically removes old, unwatched movies and TV shows by analyzing viewing history and user requests.
 - [mnamer](https://github.com/jkwill87/mnamer) - Customizable tool to automatically rename and organize media files.
 - [Multi-User Media Cleaner](https://github.com/terrelsa13/MUMC) - Query and delete unwanted media content from your Jellyfin server.
+- [plex2jellyfin](https://github.com/Nomadcxx/plex2jellyfin) - Migrates Plex libraries to Jellyfin naming (rename, dedupe, consolidate), with a daemon and companion plugin that keep new downloads organized.
 - [Squishy](https://github.com/cleverdevil/squishy) - Transcode and download your Jellyfin media with fully customizable presets and hardware acceleration.
 
 


### PR DESCRIPTION
Adds [plex2jellyfin](https://github.com/Nomadcxx/plex2jellyfin) to Media Organization.

It migrates Plex libraries to Jellyfin naming (rename, dedupe, consolidate), then a daemon and companion plugin keep new downloads organized.

## Validation
- Entry sorts alphabetically per the contributing guide; the sort-check workflow passes on this PR.
- Searched open and closed issues and PRs: no prior suggestion of plex2jellyfin exists.

## Notes
- The repo is under the 4-week age guideline (created 2026-07-09), but the project is seven months old. I developed it as [jellywatch](https://github.com/Nomadcxx/jellywatch) from January through June and renamed it in July.