### PR TITLE
feat(plugins): add jellyfin-plugin-interest-collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 - [Jellyfin.Plugin.ACdb](https://github.com/jonjonsson/Jellyfin.Plugin.ACdb) - Syncs auto-updating collections, posters, and backgrounds from [ACdb.tv](https://acdb.tv). `🔺 Paid`
 - [jellyfin-plugin-auto-collections](https://github.com/KeksBombe/jellyfin-plugin-auto-collections) - Automatically creates and maintains dynamic collections based on flexible criteria.
 - [jellyfin-plugin-collection-import](https://github.com/lostb1t/jellyfin-plugin-collection-import) - Creates and sorts collections by importing from external sources like *mdblist*.
+- [jellyfin-plugin-interest-collections](https://github.com/elisamuel40/jellyfin-plugin-interest-collections) - Tags movies and shows with granular IMDb-style interests, such as Psychological Thriller or Drug Crime, and maintains a collection per interest. `🔹 Beta`
 - [jellyfin-plugin-mindthegaps](https://github.com/IDisposable/jellyfin-plugin-mindthegaps) - Finds missing entries across your library (collections, series episodes, cast and crew filmographies) and organizes them into a fillable report.
 - [jellyfin-plugin-provider-stuff](https://github.com/kamilkosek/jellyfin-plugin-provider-stuff) - Automates tagging library items with streaming provider tags, creates collections per provider. `🔸 Stale`
 - [jellyfin-smartlists-plugin](https://github.com/jyourstone/jellyfin-smartlists-plugin) - Creates dynamic collections and playlists in Jellyfin that automatically update based on customizable rules as the library changes.


### PR DESCRIPTION
Adds [jellyfin-plugin-interest-collections](https://github.com/elisamuel40/jellyfin-plugin-interest-collections) to **Collections & Playlists**.

Jellyfin genres are coarse — *Breaking Bad* is Crime, Drama, Thriller, and so are a few hundred other titles. The plugin adds the finer layer IMDb calls **Interests**: it looks each title up by its provider id, writes the interests as Jellyfin tags, and optionally maintains one collection per interest. A title can sit in many interest collections at once without duplicating anything on disk.

### Up front, so you can judge it fairly

- **The project is new.** The repository was created on 2026-08-10, so it does not meet the "at least 4 weeks old" guideline. I am opening this now rather than sitting on it, but I completely understand if you would rather label it and revisit in a few weeks — please treat that as the default if it is your preference.
- **It is alpha**, hence the `🔹 Beta` badge. Released as `v0.1.3`, versioned semantically, with a changelog.
- **Free and open source under MIT.** No paid tier, no account, no telemetry, nothing gated. It is meant to be usable and forkable by anyone.
- **Provider caveat, stated plainly in the README.** The default provider reads IMDb's public GraphQL endpoint — structured data, not scraped HTML — and IMDb's own notice on that data limits it to non-commercial personal use. Tagging your own self-hosted library fits; redistributing the data does not. Two alternative providers ship with it for anyone who would rather not weigh that up: TMDb keywords via the official API, and a fully offline provider that derives interests from metadata Jellyfin already holds.

### What it does about the obvious risks

- It records which tags it wrote per item and only ever removes those, so tags added by users or other plugins survive.
- Collections it creates carry a provider-id stamp inside Jellyfin **and** a record in its own state; both must agree before it modifies or deletes anything, so hand-made collections are untouchable even when named identically.
- A provider outage is recorded as a failure and retried, never as "this title has no interests" — that distinction is pinned by a test, because getting it wrong would strip metadata library-wide.

### State of the repo

- 85 automated tests; CI builds with the Jellyfin analyzer set and warnings-as-errors, green on `main`.
- Targets Jellyfin 10.11.x on .NET 9, and was validated end to end against a real 10.11.11 server: 227 titles tagged, 39 collections built, then re-verified after each fix.
- Installable from its own manifest repository, and documented for Linux, Docker, Windows and macOS.

### Checklist

- [x] Conventional commit (`feat(plugins): …`)
- [x] Inserted in alphabetical order per the sorting rules (between `jellyfin-plugin-collection-import` and `jellyfin-plugin-mindthegaps`)
- [x] Searched the list for duplicates
- [x] Description kept short and non-promotional
- [x] Only `README.md` edited; no generated files touched
