### PR TITLE
feat(plugins): add ignore-empty-items

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 <!-- sort list:plugins-library -->
 - [AniLiberty STRM Plugin](https://github.com/queukat/AniLibriaStrmPlugin) - Generates AniLiberty STRM libraries for Jellyfin with metadata, intro markers, and watch-progress sync.
 - [GhostLibrary](https://github.com/upchui/Jellyfin-GhostLibrary) - Hides selected media libraries from the client home screen and library list without blocking server-side plugin or filesystem access.
+- [Ignore Empty Items](https://github.com/Rijul-A/ignore-empty-items-jellyfin) - Hides or removes Jellyfin library items that contain no associated media files while preserving the files and folders on disk.
 - [Jellyfin Ignore](https://github.com/fdett/jellyfin-ignore/) - Ignores filename patterns on library scans. `🔹 Beta` `🔸 Stale`
 - [jellyfin-local-posters](https://github.com/NooNameR/Jellyfin.Plugin.LocalPosters/) - Automatically matches and imports local posters using TPDb and MediUX filename formats. Also supports syncing posters from Google Drive.
 - [jellyfin-musictags-plugin](https://github.com/jyourstone/jellyfin-musictags-plugin) - Automatically extracts audio file metadata and converts it into standard Jellyfin tags.


### PR DESCRIPTION
This [plugin](https://github.com/Rijul-A/ignore-empty-items-jellyfin) permits Jellyfin administrators to keep media-less containers (series, seasons, movies, albums, artists) out of the user's view. It achieves this through one of the following ways, based on the configuration, after every library scan:

1. It deletes the offending items from the library. The downside of this method is that you get notifications at each such addition and deletion, if you have them enabled.
2. It tags the offending items with an admin-configured tag, and adds the tag as a blacklisted tag for each user's parental control. While this is my preferred method, the downside is that uninstallation of the plugin is a multi-step process if you want to clear the tags from the media and the users before uninstallation is complete. I have documented in the README the recommended method for this case.

Repository link with target abi `10.11.0.0` (which supports `10.11.x`).
```
https://rijul-a.github.io/ignore-empty-items-jellyfin/repository.json
```

The plugin's source repo was created on May 14, 2026 at 11:59 UTC