### PR TITLE
feat: add jellyfin-plugin-pre-transcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@
 - [jellyfin-plugin-media-cleaner](https://github.com/shemanaev/jellyfin-plugin-media-cleaner) - Automatically removes played media after a specified time period.
 - [jellyfin-plugin-MediathekViewDL](https://github.com/CatNoir2006/jellyfin-plugin-MediathekViewDL) - Integrates MediathekViewDL into Jellyfin and allows users to search, download, and manage content.
 - [jellyfin-plugin-meilisearch](https://github.com/arnesacnussem/jellyfin-plugin-meilisearch) - Enhances Jellyfin search speed and accuracy by offloading queries to a Meilisearch instance.
+- [jellyfin-plugin-pre-transcode](https://github.com/mugurc/jellyfin-plugin-pre-transcode) - Re-encodes library media in the background to a configurable compatibility baseline, so the server does not live-transcode the same files on every playback.
 - [jellyfin-powertoys](https://github.com/lennykean/jellyfin-powertoys) - A collection of plugins to enhance Jellyfin with additional features and tools.
 - [JellyfinTweaks](https://github.com/n00bcodr/JellyfinTweaks) - Overrides Jellyfin settings such as *Enable Backdrops* and *Enable Theme Music* across all devices.
 - [Jellyfin-Xtream-Library](https://github.com/firestaerter3/Jellyfin-Xtream-Library) - Syncs Xtream VOD and Series content to native Jellyfin libraries via STRM files, with automatic metadata lookup and Live TV support.


### PR DESCRIPTION
Adds [jellyfin-plugin-pre-transcode](https://github.com/mugurc/jellyfin-plugin-pre-transcode) under **Plugins → Library Management**.

It transcodes library media once, in the background, into a compatibility baseline the admin defines, so the server stops live-transcoding the same files on every playback. The codec, encoder, container, preset and tone-map options are populated by probing the server's own ffmpeg rather than being hardcoded.

Against the project criteria:

- **Age** — created 2026-07-17, so a little over five weeks.
- **Activity** — actively maintained; latest release v0.8.0.0, and issues are being answered and fixed.
- **Checks** — the build workflow is passing on `main`.
- **Documentation** — README covers what it does, why, installation via a plugin repository URL, the trigger-rule system, and a troubleshooting section.
- **Licence** — GPL-3.0.

I searched the list and the issue/PR history first; there is no existing entry or prior suggestion for it.

Placed alphabetically between `jellyfin-plugin-meilisearch` and `jellyfin-powertoys`, and I kept the description to one factual sentence per the contribution guidelines.
