### PR TITLE
feat: add LiquidFin theme

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -330,6 +330,28 @@ Better Movie/TV page layout, improved card animation on hover. [` 🔵 Get this 
 
 ---
 
+## [LiquidFin](https://github.com/dxmoc/jellyfin-liquidfin-theme) by dxmoc
+
+A dark theme built around the Liquid Glass material: translucent panes with refracted edges, specular rim light and capsule controls. Deliberately colourless, so the artwork behind the glass supplies the colour. One CSS file, no JavaScript and no external requests. [` 🔵 Get this Theme `](https://github.com/dxmoc/jellyfin-liquidfin-theme)
+
+<table>
+  <tr>
+    <td>
+      <img src="https://github.com/dxmoc/jellyfin-liquidfin-theme/blob/main/assets/home.webp?raw=true" />
+    </td>
+    <td>
+      <img src="https://github.com/dxmoc/jellyfin-liquidfin-theme/blob/main/assets/detail.webp?raw=true" />
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <img src="https://github.com/dxmoc/jellyfin-liquidfin-theme/blob/main/assets/player.webp?raw=true" />
+    </td>
+  </tr>
+</table>
+
+---
+
 ## [NetFin](https://github.com/ya0903/NetFin) by ya0903
 
 A cinematic Netflix-inspired theme with deep dark visuals, refined hover effects, and a focus on poster artwork. [` 🔵 Get this Theme `](https://github.com/ya0903/NetFin)


### PR DESCRIPTION
**LiquidFin** — a dark Jellyfin theme built around the Liquid Glass material: translucent panes with refracted edges, specular rim light, capsule controls and spring motion. Deliberately colourless, so the artwork behind the glass supplies the colour.

- Repo: https://github.com/dxmoc/jellyfin-liquidfin-theme
- Licence: MIT
- One CSS file. No JavaScript, no plugin, nothing loaded from anywhere else — no CDN assets, no remote images, no web fonts.
- Built against the 10.10 / 10.11 web client. Falls back to opaque surfaces without `backdrop-filter`, and honours `prefers-reduced-transparency`, `prefers-reduced-motion` and `prefers-contrast: more`.

Inserted alphabetically between `Jellyfin Better Styles` and `NetFin`. The three screenshots are linked from the theme's own repository.

One thing I would rather flag myself than have you find in review: the contribution guidelines ask for a project at least four weeks old, and this repo was created on 2026-08-17, so it is about a week short. It has 71 commits and five tagged releases in that time, but I understand if you would rather this waits — happy to leave the PR open until it clears the mark.
