### PR TITLE
feat: add jellyfin-plugin-autoplaylist

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 - [jellyfin-harmonie](https://github.com/mxschll/jellyfin-harmonie) - Generates smart playlists and replaces Instant Mix using audio embeddings.
 - [Jellyfin.Plugin.ACdb](https://github.com/jonjonsson/Jellyfin.Plugin.ACdb) - Syncs auto-updating collections, posters, and backgrounds from [ACdb.tv](https://acdb.tv). `🔺 Paid`
 - [jellyfin-plugin-auto-collections](https://github.com/KeksBombe/jellyfin-plugin-auto-collections) - Automatically creates and maintains dynamic collections based on flexible criteria.
+- [jellyfin-plugin-autoplaylist](https://github.com/yonie/jellyfin-plugin-autoplaylist) - Curates thematic music playlists from your library using a local LLM served by Ollama.
 - [jellyfin-plugin-collection-import](https://github.com/lostb1t/jellyfin-plugin-collection-import) - Creates and sorts collections by importing from external sources like *mdblist*.
 - [jellyfin-plugin-mindthegaps](https://github.com/IDisposable/jellyfin-plugin-mindthegaps) - Finds missing entries across your library (collections, series episodes, cast and crew filmographies) and organizes them into a fillable report.
 - [jellyfin-plugin-provider-stuff](https://github.com/kamilkosek/jellyfin-plugin-provider-stuff) - Automates tagging library items with streaming provider tags, creates collections per provider. `🔸 Stale`


### PR DESCRIPTION
Adds [jellyfin-plugin-autoplaylist](https://github.com/yonie/jellyfin-plugin-autoplaylist) to **📂 Collections & Playlists**.

A Jellyfin plugin (ABI 10.11) that builds curated music playlists from your own library using an LLM served by [Ollama](https://ollama.com). The model is shown the tracks your library actually contains and picks from them by index, so it can only ever select real items; the plugin handles reading the library, applying per-artist/length limits, writing the playlists and running on a schedule. It is not a rule-based smart-playlist generator.

Against the project criteria:

- **Age / activity:** repository created 2026-07-26, latest release v1.0.3.0 on 2026-08-20, ongoing development.
- **Checks:** the `build` workflow passes on the default branch.
- **Docs:** README covers installation, configuration and how the curation works.
- **License:** MIT.

Entry is inserted alphabetically between `jellyfin-plugin-auto-collections` and `jellyfin-plugin-collection-import`. I searched the list and open PRs first — no existing entry for this plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)