### PR TITLE
feat(clients): add Spectati

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -984,6 +984,16 @@ clients:
         owner: Malinskiy
         repo: mellow
 
+  - name: "Spectati"
+    targets: [iOS, AppleTV, macOS]
+    website: https://spectati.com
+    price:
+      free: true
+      paid: true
+    downloads:
+      - type: app-store
+        id: "6767241047"
+
 targets:
   - key: Browser
     display: "🌎 Browser-Based"


### PR DESCRIPTION
Adds Spectati to the client list.

Spectati is a native Apple client for Jellyfin, on Apple TV, iPhone, iPad and Mac. It connects Jellyfin servers alongside Plex, Emby, SMB shares and IPTV playlists, and folds them into one library with a single search and Continue Watching row. Files direct-play at full bitrate with no server-side transcoding, so the server stays idle on high-bitrate 4K remuxes.

Website: [spectati.com](https://spectati.com/)