### PR TITLE
feat: add Jellydash to Statistics & Watch History

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@
 ### 📊 Statistics & Watch History
 
 <!-- sort list:tools-stats -->
+- [Jellydash](https://github.com/themartz90/jellydash) - Self-hosted dashboard for Jellyfin with live sessions, play history, statistics and notifications.
 - [jellyfin-rewind](https://github.com/Chaphasilor/jellyfin-rewind) - A *Spotify Wrapped*-like experience for Jellyfin music listeners.
 - [jellyfin-watch-updater](https://github.com/Simon-Eklundh/jellyfin-watch-updater) - Updates `lastPlayedDate` for watched items when clients fail to set it, enabling tools such as media cleanup plugins to correctly detect watched media.
 - [JellyPlex-Watched](https://github.com/luigi311/JellyPlex-Watched) - Syncs watch history between Jellyfin, Plex, and Emby Servers.


### PR DESCRIPTION
Adds Jellydash under Companion Apps & Tools > Statistics & Watch History.

Jellydash is a self-hosted dashboard for Jellyfin with live sessions, play history, statistics and notifications. The first public release was on August 1, 2026, and the checks on `main` are passing.