### PR TITLE
Animated Covers to UI & Customization plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 
 <!-- sort list:plugins-ui -->
 - [Achievement Badges](https://github.com/ZL154/AchievementBadges_for_Jellyfin) - Unlockable viewing achievement badges that gamify Jellyfin with milestones like first watch, binge sessions, and late-night viewing with social features such as group chats and messaging.
+- [Animated Covers](https://github.com/pa-philos/jellyfin-plugin-animated-covers) - Generates lightweight animated WebP movie covers and thumbnails with per-library scoping and static cover overwrite support.
 - [HoverTrailer](https://github.com/Fovty/HoverTrailer) - Displays movie trailers on hover.
 - [InPlayerEpisodePreview](https://github.com/Namo2/InPlayerEpisodePreview) - Adds an episode list to the video player.
 - [jellyfin-editors-choice-plugin](https://github.com/lachlandcp/jellyfin-editors-choice-plugin) - Adds a Netflix-style, full-width content slider to the home page to feature selected content.


### PR DESCRIPTION
Adds [Animated Covers](https://github.com/pa-philos/jellyfin-plugin-animated- covers) to the **UI & Customization** plugins section.

### About the plugin:
 - Extracts multi-cut looping animated WebP covers and thumbnails directly from video files.
 - Ultra-lightweight (~150 KB per preview vs 3–5 MB for GIFs), preventing server Skia resizer crashes and saving bandwidth on mobile.
 - Includes per-library scoping and optional static cover overwrite support.