### PR TITLE
Remove Windows Target from Tsukimi

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -410,7 +410,7 @@ clients:
         repo: switchfin
 
   - name: "tsukimi"
-    targets: [Linux, Windows]
+    targets: [Linux]
     oss: https://github.com/tsukinaha/tsukimi
     official: false
     beta: true


### PR DESCRIPTION
Tsukimi seems to have been accidentally added to the Windows List. As far I know and I saw the repo, tsukimi is only available for Linux atm?