### PR TITLE
feat(clients): add NaviFin

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -867,6 +867,18 @@ clients:
         owner: LouisMarotta
         repo: m7-jellyfin
 
+  - name: NaviFin
+    targets: [iOS, AppleTV, macOS]
+    website: https://navifin.app
+    official: false
+    beta: false
+    price:
+      free: false
+      paid: true
+    downloads:
+      - type: app-store
+        id: "6778781788"
+
 targets:
   - key: Browser
     display: "🌎 Browser-Based"


### PR DESCRIPTION
I make NaviFin. It is a native Jellyfin client for Apple TV, Mac, iPad and iPhone, one purchase at 6.99 covering all four, and it reached the App Store this week. Closed source. Built fast with a lot of agentic coding help, because it's the world we live in today :D.

Each platform is its own app. Playback routes per file: mp4, m4v and mov go to AVPlayer, everything else goes to VLC, so your server is not asked to transcode. Downloads, Live TV with a guide, subtitle search/download, more than one server.

It needs the OS 26 releases on every device, so an older Apple TV will not run it.

Appstore: https://apps.apple.com/app/navifin/id6778781788

Beta test (free): https://navifin.app/beta

P.S. If you want to contribute by testing please sign up :d I would love some feedback!
