### PR TITLE
feat(clients): add Meringo

### DIFF
--- a/assets/clients/clients.yaml
+++ b/assets/clients/clients.yaml
@@ -867,6 +867,18 @@ clients:
         owner: LouisMarotta
         repo: m7-jellyfin
 
+  - name: Meringo
+    targets: [Android]
+    types: [Music]
+    official: false
+    website: https://meringo.app
+    price:
+      free: false
+      paid: true
+    downloads:
+      - type: google-play
+        id: app.meringo
+
 targets:
   - key: Browser
     display: "🌎 Browser-Based"


### PR DESCRIPTION
Adds Meringo, an Android music client for Jellyfin and the
Subsonic/OpenSubsonic family.

The entry goes in `assets/clients/clients.yaml` rather than `CLIENTS.md`, per
CONTRIBUTING.md.

- Website: https://meringo.app
- Google Play: https://play.google.com/store/apps/details?id=app.meringo
- Platform: Android 13 and up
- Licence: closed source, paid ($9.99 once, seven-day trial), so `oss` is
  unset and `price.paid` is true -- the same shape as the existing Symfonium
  entry.

It connects to Jellyfin and to OpenSubsonic servers (Navidrome, Airsonic,
Funkwhale, Gonic, Ampache and others) with direct play and no transcoding.
Its distinguishing feature is the USB-DAC path: it drives a USB DAC through
the USB audio class interface rather than the Android mixer, and publishes a
SHA-256 receipt of the byte stream it sent, so the bit-perfect claim can be
recomputed by a third party. Method and an independent checker script are at
https://meringo.app/verify.

Happy to adjust fields or drop the entry if it does not fit the list.

---

The YAML block to append:

```yaml
  - name: Meringo
    targets: [Android]
    types: [Music]
    official: false
    website: https://meringo.app
    price:
      free: false
      paid: true
    downloads:
      - type: google-play
        id: app.meringo
```