### PR TITLE
refactor: marked all themes as incompatible

### DIFF
--- a/.github/ISSUE_TEMPLATE/009-request-theme.yaml
+++ b/.github/ISSUE_TEMPLATE/009-request-theme.yaml
@@ -7,18 +7,18 @@ labels:
   - request
   - theme
 
-body:      
+body:
   - type: markdown
     attributes:
       value: |
         > [!IMPORTANT]
         > Before submitting, please read the **[Contribution Guidelines](https://github.com/awesome-jellyfin/awesome-jellyfin/blob/main/CONTRIBUTING.md)**.
-        >  
+        >
         > If you are familiar with GitHub and know how to create a Pull Request, please consider submitting your suggestion **directly as a PR** instead of opening an issue:
         > https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
         >
         > Pull Requests are usually reviewed faster. Issues are mainly intended for users who are unsure how to contribute via PR.
-        
+
         **Thank you so much for your help to make this list even better! 💖**
 
   - type: input
@@ -36,7 +36,7 @@ body:
       placeholder: ex. https://github.com/awesome-jellyfin/awesome-jellyfin
     validations:
       required: true
-  
+
   - type: checkboxes
     id: type
     attributes:
@@ -69,8 +69,8 @@ body:
       label: Additional Screenshots (optional)
       description: Here you can add more screenshots
     validations:
-      required: false  
-    
+      required: false
+
   - type: checkboxes
     id: checklist
     attributes:
@@ -79,6 +79,8 @@ body:
         - label: I have read the Contribution Guidelines
           required: true
         - label: I searched the list to make sure this theme is not already included
+          required: true
+        - label: I confirm this theme works with the newest version of Jellyfin
           required: true
 
   - type: textarea

--- a/THEMES.md
+++ b/THEMES.md
@@ -7,6 +7,15 @@ The preview / screenshots were taken directly from the linked repositories.
 If an image is no longer available or out of date, please create an [issue](https://github.com/awesome-jellyfin/awesome-jellyfin/issues) or a [PR](https://github.com/awesome-jellyfin/awesome-jellyfin/edit/main/THEMES.md).
 
 
+## Themes hidden pending Jellyfin v12 compatibility
+
+In an effort to make sure the themes in this list work with the newest version, the previously listed themes are hidden for now.
+
+**Missing a theme?** If you know one works with v12, open an [issue](https://github.com/awesome-jellyfin/awesome-jellyfin/issues/new/choose) or a [PR](https://github.com/awesome-jellyfin/awesome-jellyfin/edit/main/THEMES.md) and we'll add it back.
+
+<details>
+<summary>Previously listed themes (may not work with v12)</summary>
+
 ## [Abyss](https://aumgupta.github.io/abyss-jellyfin/) by [AumGupta](https://github.com/AumGupta/)
 
 A clean, minimal dark theme with frosted glass surfaces, smooth transitions, and a clutter-free home screen spotlight add-on. [` 🔵 Get this Theme `](https://github.com/AumGupta/abyss-jellyfin)
@@ -433,6 +442,8 @@ A minimal and elegant theme for Jellyfin [` 🔵 Get this Theme `](https://githu
 </table>
 
 ---
+
+</details>
 
 <!--lint ignore unordered-list-marker-style-->
 * Stale / Inactive / May not work anymore ` 📅 `


### PR DESCRIPTION
In an effort to keep the THEMES up-to-date and make sure they work with the newest version, let's mark all existing themes as deprecated and add them back if they are known to be working with the latest JF version.