### PR TITLE
feat(plugins): add Jellyfin.Plugin.BulsatcomChannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@
 - [jellyfin-local-posters](https://github.com/NooNameR/Jellyfin.Plugin.LocalPosters/) - Automatically matches and imports local posters using TPDb and MediUX filename formats. Also supports syncing posters from Google Drive.
 - [jellyfin-musictags-plugin](https://github.com/jyourstone/jellyfin-musictags-plugin) - Automatically extracts audio file metadata and converts it into standard Jellyfin tags.
 - [jellyfin-plugin-air-times](https://github.com/k0d13/jellyfin-air-times) - Provides localized series air times based on server location. `🔸 Stale`
+- [Jellyfin.Plugin.BulsatcomChannel](https://github.com/HA-HUB-I/Jellyfin-bsc) - Generates M3U playlists and XMLTV EPG from Bulsatcom IPTV API with channel logos and live category enrichment. `✅ JF12`
 - [jellyfin-plugin-enigma2](https://github.com/knackebrot/jellyfin-plugin-enigma2) - Supports Vu+ & Enigma2 live TV streamers. `🔸 Stale`
 - [jellyfin-plugin-languageTags](https://github.com/TheXaman/jellyfin-plugin-languageTags) - Adds language tags to media based on audio tracks using FFmpeg.
 - [jellyfin-plugin-localrecs](https://github.com/rdpharr/jellyfin-plugin-localrecs) - Generates personalized movie and TV recommendations based on local watch history without external services required.


### PR DESCRIPTION
Adds [Jellyfin.Plugin.BulsatcomChannel](https://github.com/HA-HUB-I/Jellyfin-bsc) to **📚 Library Management**.

A Jellyfin plugin that integrates Bulsatcom IPTV into Jellyfin by generating M3U playlists and XMLTV EPG directly into the plugin data directory. It features transparent logo delivery for all channels, live category enrichment for Movies, Series, Sports, News, and Kids, and dynamic stream resolution.

### Project Criteria

- **Age / Activity:** Repository was created in October 2025 (~11 months ago), actively maintained with recent releases (v1.2.5.0).
- **Compatibility:** Multi-targets both .NET 10 (Jellyfin 12+, ABI `12.0.0.0` - marked with `✅ JF12`) and .NET 9 (Jellyfin 10.11.x, ABI `10.11.0.0`).
- **Checks:** Automated CI build workflow compiles both targets and generates release artifacts.
- **Documentation:** README provides clear installation instructions, manifest repository URL, and configuration options.
- **Open Source:** Free and open source on GitHub.

### Checklist

- [x] Conventional commit (`feat(plugins): ...`)
- [x] Inserted in alphabetical order per the sorting rules (between `jellyfin-plugin-air-times` and `jellyfin-plugin-enigma2`)
- [x] Searched the list for duplicates
- [x] Description kept short, descriptive, and non-promotional
- [x] Only `README.md` edited; no generated files touched
