### PR TITLE
docs: add Allociné ratings plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@
 <!-- sort list:metadata-providers -->
 - [jellyfin-imdb-rating-updater](https://github.com/voc0der/jellyfin-imdb-rating-updater) - Downloads the IMDb ratings dataset daily and updates the CommunityRating field for library items with an IMDb ID without modifying other metadata.
 - [Jellyfin Oscars](https://github.com/FizzyMUC/jellyfin-oscars-plugin) - Adds Academy Awards metadata and Oscar badges to movie detail pages.
+- [Jellyfin.Plugin.Allocine](https://github.com/charlesbel/Jellyfin.Plugin.Allocine) - Displays Allociné press and audience ratings alongside Jellyfin's existing ratings. `✅ JF12`
 - [jellyfin-plugin-AnimeMultiSource](https://github.com/webbster64/jellyfin-plugin-AnimeMultiSource) - Aggregates anime metadata, tags, artwork, and people from multiple sources (AniList, AniDB, MAL/Jikan, TVDB, Fanart.tv) with rate limiting and persistent caching for large libraries.
 - [jellyfin-plugin-applemusic](https://github.com/lyarenei/jellyfin-plugin-applemusic) - Fetches album and artist metadata from Apple Music.
 - [Jellyfin.Plugin.ArtworkMultiSource](https://github.com/Druidblack/Jellyfin.Plugin.ArtworkMultiSource) - Combines posters and logos from TMDb and TVDB with language-aware priority and configurable sorting.


### PR DESCRIPTION
## Summary

Adds Jellyfin.Plugin.Allocine to the Metadata Providers section. The plugin displays Allociné press and audience ratings alongside Jellyfin's existing ratings and supports Jellyfin 12.

## Checklist

- The project is more than four weeks old.
- The repository has current releases and documentation.
- The entry is placed according to the list's alphabetical sorting rules.
- The description is short and non-promotional.