### PR TITLE
feat(plugins): add RK Simkl Scrobbler

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 - [Moonbase](https://github.com/Moonfin-Client/Plugin) - Companion plugin for Moonfin clients, providing server-side settings sync, integrations, and a hosted Moonfin Web interface.
 - [MyAnimeSync](https://github.com/iankiller77/MyAnimeSync) - Automatically synchronizes anime watching progress between Jellyfin and MyAnimeList.
 - [Plexyfin](https://github.com/cleverdevil/plexyfin) - Automatically synchronizes artwork and collections from Plex to Jellyfin.
+- [RK Simkl Scrobbler](https://github.com/romskidd/jellyfin-plugin-simkl-scrobbler) - Scrobbles what each Jellyfin user watches to Simkl in real time, with self-service account linking and an optional two-way history sync. `✅ JF12`
 - [Shokofin](https://github.com/ShokoAnime/Shokofin) - Integrates [Shoko Server](https://shokoanime.com/downloads/shoko-server) with Jellyfin for anime library management. `✅ JF12`
 
 


### PR DESCRIPTION
Adds RK Simkl Scrobbler to Integration & Sync.

A Jellyfin plugin that scrobbles to [Simkl](https://simkl.com) in real time. Each
Jellyfin profile has its own Simkl login, and a user without dashboard access can link
their own account from a self-service page. The watch history can also be reconciled in
both directions (Simkl to Jellyfin, Jellyfin to Simkl), with a preview before anything is
written and a 7-day undo.

- Repository: https://github.com/romskidd/jellyfin-plugin-simkl-scrobbler
- Project page: https://romskidd.github.io/jellyfin-plugin-simkl-scrobbler/
- Runs on Jellyfin 10.11.x and 12.0 — one build, tested on both, hence the `✅ JF12` badge
- GPL-3.0. It started as a fork of the official [jellyfin-plugin-simkl](https://github.com/jellyfin/jellyfin-plugin-simkl), which is still maintained; this is not meant as a replacement for it
- Inserted between Plexyfin and Shokofin, per the sorting rules

Happy to reword the description if it reads too long for the list.
